### PR TITLE
Release: v0.2.0 – Add Cloudflare Rulesets Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,39 @@ module "zone" {
 }
 ```
 
+### Create rulesets
+
+```hcl
+module "zone" {
+  source      = "github.com/rashedobaid/terraform-cloudflare-zone"
+  
+  account_id  = "your-cloudflare-account-id"
+  zone        = "example.com"
+  
+  rulesets = [
+    {
+      phase = "http_request_dynamic_redirect"
+      rules = [
+        {
+          description = "Redirect to example.net"
+          expression  = "http.host eq \"example.net\""
+          action      = "redirect"
+          action_parameters = {
+            from_value = {
+              target_url = {
+                value = "https://example.net"
+              }
+              status_code           = 301
+              preserve_query_string = true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -91,6 +124,7 @@ No modules.
 | [cloudflare_argo_smart_routing.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/argo_smart_routing) | resource |
 | [cloudflare_argo_tiered_caching.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/argo_tiered_caching) | resource |
 | [cloudflare_dns_record.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) | resource |
+| [cloudflare_ruleset.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset) | resource |
 | [cloudflare_zone.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zone) | resource |
 | [cloudflare_zones.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/data-sources/zones) | data source |
 
@@ -103,6 +137,7 @@ No modules.
 | <a name="input_argo_smart_routing_enabled"></a> [argo\_smart\_routing\_enabled](#input\_argo\_smart\_routing\_enabled) | Enable smart routing as part of Argo features. | `bool` | `true` | no |
 | <a name="input_argo_tiered_caching_enabled"></a> [argo\_tiered\_caching\_enabled](#input\_argo\_tiered\_caching\_enabled) | Enable tiered caching as part of Argo features. | `bool` | `true` | no |
 | <a name="input_records"></a> [records](#input\_records) | List of DNS records to be created within the zone. | `list(any)` | `[]` | no |
+| <a name="input_rulesets"></a> [rulesets](#input\_rulesets) | List of Rulesets to be created within the zone. | `list(any)` | `[]` | no |
 | <a name="input_type"></a> [type](#input\_type) | Type of zone: 'full' for Cloudflare-managed DNS, or 'partial' for CNAME setup. | `string` | `"full"` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The domain name of the Cloudflare zone (e.g., example.com). | `string` | n/a | yes |
 | <a name="input_zone_enabled"></a> [zone\_enabled](#input\_zone\_enabled) | Determines whether to create a new DNS zone. If set to false, uses an existing zone. | `bool` | `true` | no |
@@ -115,6 +150,7 @@ No modules.
 | <a name="output_meta_phishing_detected"></a> [meta\_phishing\_detected](#output\_meta\_phishing\_detected) | Indicates whether phishing content has been detected on the zone. |
 | <a name="output_name_servers"></a> [name\_servers](#output\_name\_servers) | List of Cloudflare-assigned name servers. Only populated for zones using full DNS setup. |
 | <a name="output_record_key_to_id"></a> [record\_key\_to\_id](#output\_record\_key\_to\_id) | Map of record keys (name-type-content) to record IDs. |
+| <a name="output_ruleset_ids"></a> [ruleset\_ids](#output\_ruleset\_ids) | Map of ruleset phases to their corresponding IDs. |
 | <a name="output_status"></a> [status](#output\_status) | Current status of the zone (e.g., 'active', 'pending'). |
 | <a name="output_type"></a> [type](#output\_type) | The zone type, indicating the plan or configuration applied (e.g., 'full' or 'partial'). |
 | <a name="output_vanity_name_servers"></a> [vanity\_name\_servers](#output\_vanity\_name\_servers) | List of custom vanity name servers assigned to the zone, if configured. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,8 @@ output "verification_key" {
   description = "TXT record value used to verify domain ownership. Applicable only for zones of type 'partial'."
   value       = join("", compact(cloudflare_zone.default[*].verification_key))
 }
+
+output "ruleset_ids" {
+  description = "Map of ruleset phases to their corresponding IDs."
+  value       = { for k, rs in cloudflare_ruleset.default : k => rs.id }
+}

--- a/ruleset.tf
+++ b/ruleset.tf
@@ -8,6 +8,6 @@ resource "cloudflare_ruleset" "default" {
   zone_id = local.zone_id
   kind    = "zone"
   name    = "default"
-  phase   = each.value.phase
+  phase   = each.key
   rules   = lookup(each.value, "rules", [])
 }

--- a/ruleset.tf
+++ b/ruleset.tf
@@ -1,0 +1,13 @@
+locals {
+  rulesets = { for rs in var.rulesets : rs.phase => rs }
+}
+
+resource "cloudflare_ruleset" "default" {
+  for_each = local.rulesets
+
+  zone_id = local.zone_id
+  kind    = "zone"
+  name    = "default"
+  phase   = each.value.phase
+  rules   = lookup(each.value, "rules", [])
+}

--- a/variables.tf
+++ b/variables.tf
@@ -43,3 +43,9 @@ variable "argo_smart_routing_enabled" {
   type        = bool
   default     = true
 }
+
+variable "rulesets" {
+  description = "List of Rulesets to be created within the zone."
+  type        = list(any)
+  default     = []
+}


### PR DESCRIPTION
This PR introduces version (`v0.2.0`) of the `terraform-cloudflare-zone` module. It adds support for managing Cloudflare Rulesets, allowing users to define custom security logic for different request phases within a zone.

### Features Included:

- **Ruleset Management**
  - Dynamically create rulesets for different phases using the `rulesets` input.
  - Supports any valid ruleset `phase` (e.g., `http_request_firewall_custom`, `http_request_sanitize`).
  - Rules are defined per phase and provisioned using `for_each`.

- **Output Enhancements**
  - Exposes a new output `ruleset_ids`:
    - Returns a map of phase names to their corresponding Cloudflare ruleset IDs.

- **Input Variable**
  - `rulesets`: List of ruleset objects that include:
    - `phase`: The lifecycle phase for the ruleset.
    - `rules`: A list of Cloudflare rules (with support for `expression`, `action`, `enabled`, etc.).

### Highlights:

- Uses `locals` and `for_each` to dynamically construct multiple `cloudflare_ruleset` resources by phase.
- Clean separation of logic by request phase for better security policy management.
- Backward-compatible; default behavior is a no-op unless `rulesets` is explicitly set.
- Built using the latest [Cloudflare Terraform provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset) with full support for `zone`-level rulesets.
