### PR TITLE
Release: v0.2.1 – Support for unmanaged Cloudflare DNS Records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+.terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -1,29 +1,41 @@
 # Terraform Cloudflare Zone
 
-Terraform module that manages Cloudflare zones, DNS records, and optional [Argo Smart Routing](https://developers.cloudflare.com/argo-smart-routing/) and [Tiered Caching](https://developers.cloudflare.com/cache/about/tiered-cache/).
+Terraform module that manages Cloudflare zones, DNS records, optional [Argo Smart Routing](https://developers.cloudflare.com/argo-smart-routing/), [Tiered Caching](https://developers.cloudflare.com/cache/about/tiered-cache/), and [Rulesets](https://developers.cloudflare.com/ruleset-engine/about/rulesets/).
 
 This module supports:
 
 - Creating or using an existing Cloudflare zone.
-- Managing multiple DNS records.
-- Enabling and configuring Cloudflare Argo features.
+- Managing multiple DNS records, including:
+  - Full control over TTL, proxying, priority, and comments.
+  - Ability to ignore content changes for external systems like DDNS.
+- Enabling and configuring Cloudflare Argo features:
+  - Smart Routing
+  - Tiered Caching
+- Defining custom Cloudflare Rulesets (e.g., redirect logic, access policies).
 
-## Examples
+## Example
 
 ### Create new zone
 
 ```hcl
 module "zone" {
-  source      = "github.com/rashedobaid/terraform-cloudflare-zone"
+  source  = "rashedobaid/zone/cloudflare"
 
-  account_id  = "your-cloudflare-account-id"
-  zone        = "example.com"
+  # Required Cloudflare account ID
+  account_id = "your-cloudflare-account-id"
 
-  # Optional: Enable Argo features
+  # Domain name to create/manage in Cloudflare
+  zone = "example.com"
+
+  # Whether to create a new zone or use an existing one
+  zone_enabled = true
+
+  # Enable Argo features
   argo_enabled                 = true
   argo_smart_routing_enabled   = true
   argo_tiered_caching_enabled  = true
 
+  # DNS records to manage
   records = [
     {
       name    = "www"
@@ -31,6 +43,7 @@ module "zone" {
       content = "192.0.2.1"
       ttl     = 300
       proxied = true
+      comment = "Main website"
     },
     {
       name     = "@"
@@ -38,51 +51,26 @@ module "zone" {
       content  = "mail.example.com"
       ttl      = 3600
       priority = 10
-    }
-  ]
-}
-```
-
-### Use existing zone
-
-```hcl
-module "zone" {
-  source      = "github.com/rashedobaid/terraform-cloudflare-zone"
-  
-  account_id  = "your-cloudflare-account-id"
-  zone        = "example.com"
-
-  # Use existing zone (do not create)
-  zone_enabled = false 
-
-  records = [
+      comment  = "Mail server"
+    },
     {
-      name    = "app"
-      type    = "CNAME"
-      content = "app.example.net"
-      ttl     = 300
-      proxied = false
+      name    = "vpn"
+      type    = "A"
+      content = "dynamic.example.com"
+      ttl     = 120
+      managed = false            # This record is managed externally (e.g., DDNS)
+      comment = "Dynamic IP from DDNS"
     }
   ]
-}
-```
 
-### Create rulesets
-
-```hcl
-module "zone" {
-  source      = "github.com/rashedobaid/terraform-cloudflare-zone"
-  
-  account_id  = "your-cloudflare-account-id"
-  zone        = "example.com"
-  
+  # Optional rulesets to apply
   rulesets = [
     {
       phase = "http_request_dynamic_redirect"
       rules = [
         {
-          description = "Redirect to example.net"
-          expression  = "http.host eq \"example.net\""
+          description = "Redirect example.com to example.net"
+          expression  = "http.host eq \"example.com\""
           action      = "redirect"
           action_parameters = {
             from_value = {
@@ -124,6 +112,7 @@ No modules.
 | [cloudflare_argo_smart_routing.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/argo_smart_routing) | resource |
 | [cloudflare_argo_tiered_caching.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/argo_tiered_caching) | resource |
 | [cloudflare_dns_record.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) | resource |
+| [cloudflare_dns_record.unmanaged](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) | resource |
 | [cloudflare_ruleset.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset) | resource |
 | [cloudflare_zone.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zone) | resource |
 | [cloudflare_zones.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/data-sources/zones) | data source |

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ This module supports:
 
 ## Example
 
-### Create new zone
-
 ```hcl
 module "zone" {
   source  = "rashedobaid/zone/cloudflare"

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,13 @@ locals {
     for index, record in var.records :
     try(record.key, format("%s-%s-%s", record.name, record.type, record.content)) => record
   } : {}
+  records_name = {
+    for k, v in local.records : k => (
+      v.name == "@" || v.name == local.zone_name
+      ) ? local.zone_name : (
+      endswith(v.name, ".${local.zone_name}") ? v.name : "${v.name}.${local.zone_name}"
+    )
+  }
   argo_enabled   = var.argo_enabled
   tiered_caching = local.argo_enabled && var.argo_tiered_caching_enabled ? "on" : "off"
   smart_routing  = local.argo_enabled && var.argo_smart_routing_enabled ? "on" : "off"
@@ -33,20 +40,34 @@ resource "cloudflare_zone" "default" {
 }
 
 resource "cloudflare_dns_record" "default" {
-  for_each = local.records
+  for_each = { for k, v in local.records : k => v if try(v.managed, true) }
 
-  zone_id = local.zone_id
-  name = (
-    each.value.name == "@" || each.value.name == local.zone_name
-    ) ? local.zone_name : (
-    endswith(each.value.name, ".${local.zone_name}") ? each.value.name : "${each.value.name}.${local.zone_name}"
-  )
+  zone_id  = local.zone_id
+  name     = local.records_name[each.key]
   type     = each.value.type
   content  = each.value.content
   ttl      = lookup(each.value, "ttl", 1)
   priority = lookup(each.value, "priority", null)
   proxied  = lookup(each.value, "proxied", false)
   comment  = lookup(each.value, "comment", null)
+}
+
+# The DNS record resource when we are **not** managing the content, such as when using DDNS or Cloudflare API:
+resource "cloudflare_dns_record" "unmanaged" {
+  for_each = { for k, v in local.records : k => v if !try(v.managed, true) }
+
+  zone_id  = local.zone_id
+  name     = local.records_name[each.key]
+  type     = each.value.type
+  content  = each.value.content
+  ttl      = lookup(each.value, "ttl", 1)
+  priority = lookup(each.value, "priority", null)
+  proxied  = lookup(each.value, "proxied", false)
+  comment  = lookup(each.value, "comment", null)
+
+  lifecycle {
+    ignore_changes = [content]
+  }
 }
 
 resource "cloudflare_argo_smart_routing" "default" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,10 @@ output "id" {
 
 output "record_key_to_id" {
   description = "Map of record keys (name-type-content) to record IDs."
-  value       = { for k, record in cloudflare_dns_record.default : k => record.id }
+  value = merge(
+    { for k, record in cloudflare_dns_record.default   : k => record.id },
+    { for k, record in cloudflare_dns_record.unmanaged : k => record.id }
+  )
 }
 
 output "type" {

--- a/ruleset.tf
+++ b/ruleset.tf
@@ -1,5 +1,5 @@
 locals {
-  rulesets = { for rs in var.rulesets : rs.phase => rs }
+  rulesets = { for rs in var.rulesets : "${lookup(rs, "name", "default")}_${rs.phase}" => rs }
 }
 
 resource "cloudflare_ruleset" "default" {
@@ -7,7 +7,7 @@ resource "cloudflare_ruleset" "default" {
 
   zone_id = local.zone_id
   kind    = "zone"
-  name    = "default"
-  phase   = each.key
+  name    = lookup(each.value, "name", "default")
+  phase   = each.value.phase
   rules   = lookup(each.value, "rules", [])
 }


### PR DESCRIPTION
This PR introduces version (`v0.2.1`) of the `terraform-cloudflare-zone` module. It enhances support for managing Cloudflare Rulesets and introduces fine-grained control over DNS record management.

### Features Included:

- **Ruleset Management Enhancements**
  - Supports uniquely named rulesets using a `name` field.
  - Dynamically creates rulesets per `<name>_<phase>` using `for_each`.
  - Backward-compatible default behavior using `"default"` name when omitted.

- **DNS Record Management Enhancements**
  - Adds support for **unmanaged** DNS records:
    - Records with `managed = false` will be created with `lifecycle.ignore_changes = [content]`.
    - Useful for records updated via external systems like DDNS or dynamic APIs.
  - Existing `cloudflare_dns_record.default` is now limited to records where `managed = true` or unset (defaults to true).

- **Output Enhancements**
  - Exposes a new output `ruleset_ids`:
    - Returns a map of `<name>_<phase>` to their corresponding Cloudflare ruleset IDs.

### Highlights:

- Introduces `cloudflare_dns_record.unmanaged` resource to support external DNS control while still tracking them in Terraform.
- Uses `locals` and `for_each` to construct rulesets dynamically by name and phase.
- Clean and predictable naming for DNS records based on the zone and record name.
- Backward-compatible; no changes occur unless `rulesets` or `managed = false` is explicitly provided.
