### PR TITLE
Release: v0.1.0 – Initial Terraform Cloudflare Zone Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Local .terraform directories
+.terraform/
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,143 @@
+# Terraform Cloudflare Zone
+
+Terraform module that manages Cloudflare zones, DNS records, optional [Argo Smart Routing](https://developers.cloudflare.com/argo-smart-routing/), [Tiered Caching](https://developers.cloudflare.com/cache/about/tiered-cache/), and [Rulesets](https://developers.cloudflare.com/ruleset-engine/about/rulesets/).
+
+This module supports:
+
+- Creating or using an existing Cloudflare zone.
+- Managing multiple DNS records, including:
+  - Full control over TTL, proxying, priority, and comments.
+- Enabling and configuring Cloudflare Argo features:
+  - Smart Routing
+  - Tiered Caching
+- Defining custom Cloudflare Rulesets (e.g., redirect logic, access policies).
+
+## Example
+
+```hcl
+module "zone" {
+  source  = "rashedobaid/zone/cloudflare"
+
+  # Required Cloudflare account ID
+  account_id = "your-cloudflare-account-id"
+
+  # Domain name to create/manage in Cloudflare
+  zone = "example.com"
+
+  # Whether to create a new zone or use an existing one
+  zone_enabled = true
+
+  # Enable Argo features
+  argo_enabled                 = true
+  argo_smart_routing_enabled   = true
+  argo_tiered_caching_enabled  = true
+
+  # DNS records to manage
+  records = [
+    {
+      name    = "www"
+      type    = "A"
+      content = "192.0.2.1"
+      ttl     = 300
+      proxied = true
+      comment = "Main website"
+    },
+    {
+      name     = "@"
+      type     = "MX"
+      content  = "mail.example.com"
+      ttl      = 3600
+      priority = 10
+      comment  = "Mail server"
+    }
+  ]
+
+  # Optional rulesets to apply
+  rulesets = [
+    {
+      phase = "http_request_dynamic_redirect"
+      rules = [
+        {
+          description = "Redirect example.com to example.net"
+          expression  = "http.host eq \"example.com\""
+          action      = "redirect"
+          action_parameters = {
+            from_value = {
+              target_url = {
+                value = "https://example.net"
+              }
+              status_code           = 301
+              preserve_query_string = true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 5.5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | 5.5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [cloudflare_argo_smart_routing.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/argo_smart_routing) | resource |
+| [cloudflare_argo_tiered_caching.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/argo_tiered_caching) | resource |
+| [cloudflare_dns_record.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) | resource |
+| [cloudflare_ruleset.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset) | resource |
+| [cloudflare_zone.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/zone) | resource |
+| [cloudflare_zones.default](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/data-sources/zones) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The Cloudflare account ID associated with the zone. | `string` | n/a | yes |
+| <a name="input_argo_enabled"></a> [argo\_enabled](#input\_argo\_enabled) | Whether to enable Cloudflare Argo for the zone. | `bool` | `false` | no |
+| <a name="input_argo_smart_routing_enabled"></a> [argo\_smart\_routing\_enabled](#input\_argo\_smart\_routing\_enabled) | Enable smart routing as part of Argo features. | `bool` | `true` | no |
+| <a name="input_argo_tiered_caching_enabled"></a> [argo\_tiered\_caching\_enabled](#input\_argo\_tiered\_caching\_enabled) | Enable tiered caching as part of Argo features. | `bool` | `true` | no |
+| <a name="input_records"></a> [records](#input\_records) | List of DNS records to be created within the zone. | `list(any)` | `[]` | no |
+| <a name="input_rulesets"></a> [rulesets](#input\_rulesets) | List of Rulesets to be created within the zone. | `list(any)` | `[]` | no |
+| <a name="input_type"></a> [type](#input\_type) | Type of zone: 'full' for Cloudflare-managed DNS, or 'partial' for CNAME setup. | `string` | `"full"` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | The domain name of the Cloudflare zone (e.g., example.com). | `string` | n/a | yes |
+| <a name="input_zone_enabled"></a> [zone\_enabled](#input\_zone\_enabled) | Determines whether to create a new DNS zone. If set to false, uses an existing zone. | `bool` | `true` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | The unique identifier of the Cloudflare zone. |
+| <a name="output_meta_phishing_detected"></a> [meta\_phishing\_detected](#output\_meta\_phishing\_detected) | Indicates whether phishing content has been detected on the zone. |
+| <a name="output_name_servers"></a> [name\_servers](#output\_name\_servers) | List of Cloudflare-assigned name servers. Only populated for zones using full DNS setup. |
+| <a name="output_record_key_to_id"></a> [record\_key\_to\_id](#output\_record\_key\_to\_id) | Map of record keys (name-type-content) to record IDs. |
+| <a name="output_ruleset_ids"></a> [ruleset\_ids](#output\_ruleset\_ids) | Map of ruleset phases to their corresponding IDs. |
+| <a name="output_status"></a> [status](#output\_status) | Current status of the zone (e.g., 'active', 'pending'). |
+| <a name="output_type"></a> [type](#output\_type) | The zone type, indicating the plan or configuration applied (e.g., 'full' or 'partial'). |
+| <a name="output_vanity_name_servers"></a> [vanity\_name\_servers](#output\_vanity\_name\_servers) | List of custom vanity name servers assigned to the zone, if configured. |
+| <a name="output_verification_key"></a> [verification\_key](#output\_verification\_key) | TXT record value used to verify domain ownership. Applicable only for zones of type 'partial'. |
+<!-- END_TF_DOCS -->
+
+## Authors
+
+Module is maintained by [Rashed Obaid](https://github.com/rashedobaid).
+
+## License
+
+Apache 2 Licensed. See [LICENSE](https://github.com/rashedobaid/terraform-cloudflare-zone/tree/main/LICENSE) for full details.

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,64 @@
+locals {
+  zone_enabled    = var.zone_enabled
+  zone_exists     = !var.zone_enabled
+  zone_id         = local.zone_enabled ? join("", cloudflare_zone.default[*].id) : (local.zone_exists ? data.cloudflare_zones.default[0].result[0].id : null)
+  zone_name       = local.zone_enabled ? cloudflare_zone.default[0].name : (local.zone_exists ? data.cloudflare_zones.default[0].result[0].name : null)
+  records_enabled = length(var.records) > 0
+  records = local.records_enabled ? {
+    for index, record in var.records :
+    try(record.key, format("%s-%s-%s", record.name, record.type, record.content)) => record
+  } : {}
+  argo_enabled   = var.argo_enabled
+  tiered_caching = local.argo_enabled && var.argo_tiered_caching_enabled ? "on" : "off"
+  smart_routing  = local.argo_enabled && var.argo_smart_routing_enabled ? "on" : "off"
+}
+
+data "cloudflare_zones" "default" {
+  count = local.zone_exists ? 1 : 0
+
+  account = {
+    id = var.account_id
+  }
+  name = var.zone
+}
+
+resource "cloudflare_zone" "default" {
+  count = local.zone_enabled ? 1 : 0
+
+  account = {
+    id = var.account_id
+  }
+  name = var.zone
+  type = var.type
+}
+
+resource "cloudflare_dns_record" "default" {
+  for_each = local.records
+
+  zone_id = local.zone_id
+  name = (
+    each.value.name == "@" || each.value.name == local.zone_name
+    ) ? local.zone_name : (
+    endswith(each.value.name, ".${local.zone_name}") ? each.value.name : "${each.value.name}.${local.zone_name}"
+  )
+  type     = each.value.type
+  content  = each.value.content
+  ttl      = lookup(each.value, "ttl", 1)
+  priority = lookup(each.value, "priority", null)
+  proxied  = lookup(each.value, "proxied", false)
+  comment  = lookup(each.value, "comment", null)
+}
+
+resource "cloudflare_argo_smart_routing" "default" {
+  count = local.argo_enabled ? 1 : 0
+
+  zone_id = local.zone_id
+  value   = local.smart_routing
+}
+
+resource "cloudflare_argo_tiered_caching" "default" {
+  count = local.argo_enabled ? 1 : 0
+
+  zone_id = local.zone_id
+  value   = local.tiered_caching
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,44 @@
+output "id" {
+  description = "The unique identifier of the Cloudflare zone."
+  value       = try(local.zone_id, null)
+}
+
+output "record_key_to_id" {
+  description = "Map of record keys (name-type-content) to record IDs."
+  value       = { for k, record in cloudflare_dns_record.default : k => record.id }
+}
+
+output "type" {
+  description = "The zone type, indicating the plan or configuration applied (e.g., 'full' or 'partial')."
+  value       = join("", cloudflare_zone.default[*].type)
+}
+
+output "vanity_name_servers" {
+  description = "List of custom vanity name servers assigned to the zone, if configured."
+  value       = try(cloudflare_zone.default[*].vanity_name_servers, null)
+}
+
+output "meta_phishing_detected" {
+  description = "Indicates whether phishing content has been detected on the zone."
+  value       = join("", cloudflare_zone.default[*].meta.phishing_detected)
+}
+
+output "status" {
+  description = "Current status of the zone (e.g., 'active', 'pending')."
+  value       = join("", cloudflare_zone.default[*].status)
+}
+
+output "name_servers" {
+  description = "List of Cloudflare-assigned name servers. Only populated for zones using full DNS setup."
+  value       = try(cloudflare_zone.default[*].name_servers, null)
+}
+
+output "verification_key" {
+  description = "TXT record value used to verify domain ownership. Applicable only for zones of type 'partial'."
+  value       = join("", compact(cloudflare_zone.default[*].verification_key))
+}
+
+output "ruleset_ids" {
+  description = "Map of ruleset phases to their corresponding IDs."
+  value       = { for k, rs in cloudflare_ruleset.default : k => rs.id }
+}

--- a/ruleset.tf
+++ b/ruleset.tf
@@ -1,0 +1,13 @@
+locals {
+  rulesets = { for rs in var.rulesets : "${lookup(rs, "name", "default")}_${rs.phase}" => rs }
+}
+
+resource "cloudflare_ruleset" "default" {
+  for_each = local.rulesets
+
+  zone_id = local.zone_id
+  kind    = "zone"
+  name    = lookup(each.value, "name", "default")
+  phase   = each.value.phase
+  rules   = lookup(each.value, "rules", [])
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,51 @@
+variable "account_id" {
+  description = "The Cloudflare account ID associated with the zone."
+  type        = string
+}
+
+variable "zone" {
+  description = "The domain name of the Cloudflare zone (e.g., example.com)."
+  type        = string
+}
+
+variable "zone_enabled" {
+  description = "Determines whether to create a new DNS zone. If set to false, uses an existing zone."
+  type        = bool
+  default     = true
+}
+
+variable "type" {
+  description = "Type of zone: 'full' for Cloudflare-managed DNS, or 'partial' for CNAME setup."
+  type        = string
+  default     = "full"
+}
+
+variable "records" {
+  description = "List of DNS records to be created within the zone."
+  type        = list(any)
+  default     = []
+}
+
+variable "argo_enabled" {
+  description = "Whether to enable Cloudflare Argo for the zone."
+  type        = bool
+  default     = false
+}
+
+variable "argo_tiered_caching_enabled" {
+  description = "Enable tiered caching as part of Argo features."
+  type        = bool
+  default     = true
+}
+
+variable "argo_smart_routing_enabled" {
+  description = "Enable smart routing as part of Argo features."
+  type        = bool
+  default     = true
+}
+
+variable "rulesets" {
+  description = "List of Rulesets to be created within the zone."
+  type        = list(any)
+  default     = []
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">= 5.5.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces the initial version (`v0.1.0`) of the `terraform-cloudflare-zone` module. It enables flexible and opinionated provisioning of a Cloudflare DNS zone and associated resources using Terraform.

### Features Included:
- **Zone Management**  
  - Create a new zone or reference an existing one using `var.zone_enabled`.  
  - Dynamically resolve `zone_id` and `zone_name` based on mode (create or reference).

- **DNS Record Management**  
  - Create DNS records dynamically via the `records` input.  
  - Supports optional attributes like `ttl`, `priority`, `proxied`, and `comment`.

- **Argo Smart Routing & Tiered Caching**  
  - Conditional enablement based on `argo_enabled` and specific flags:  
    - `argo_smart_routing_enabled`  
    - `argo_tiered_caching_enabled`

- **Ruleset Management**
  - Dynamically create rulesets for different phases using the `rulesets` input.
  - Supports any valid ruleset `phase` (e.g., `http_request_firewall_custom`, `http_request_sanitize`).
  - Rules are defined per phase and provisioned using `for_each`.

- **Output Enhancements**
  - Exposes a new output `ruleset_ids`:
    - Returns a map of phase names to their corresponding Cloudflare ruleset IDs.

- **Input Variable**
  - `rulesets`: List of ruleset objects that include:
    - `phase`: The lifecycle phase for the ruleset.
    - `rules`: A list of Cloudflare rules (with support for `expression`, `action`, `enabled`, etc.).

### Highlights:
- Modular and ready for extension with more Cloudflare features.
- Supports conditional logic for zone creation vs. lookup.
- Clean separation of logic by request phase for better security policy management.
- Backward-compatible; default behavior is a no-op unless `rulesets` is explicitly set.
- Built using the latest [Cloudflare Terraform provider](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/ruleset) (`v5.5.0`) with full support for `zone`-level rulesets.
- Uses `locals` and `for_each` to dynamically construct DNS records and rulesets based on input.
