### PR TITLE
Release: v0.1.1 - Add optional `data` and `settings` support to Cloudflare DNS records

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,8 @@ resource "cloudflare_dns_record" "default" {
   ttl      = lookup(each.value, "ttl", 1)
   priority = lookup(each.value, "priority", null)
   proxied  = lookup(each.value, "proxied", false)
+  data     = lookup(each.value, "data", null)
+  settings = lookup(each.value, "settings", null)
   comment  = lookup(each.value, "comment", null)
 }
 


### PR DESCRIPTION
This PR updates the Cloudflare DNS record implementation to support additional optional attributes exposed by the Cloudflare provider. The change enhances flexibility when managing DNS records by allowing advanced record configuration without breaking existing behavior.

## Changes Introduced

### DNS Record Enhancements
- Added support for the following optional attributes on `cloudflare_dns_record`:
  - `data`
  - `settings`
- Both attributes are conditionally populated using `lookup(...)` to preserve backward compatibility.
- Existing record logic (name normalization, TTL, priority, proxied, comment) remains unchanged.

### Implementation Details
- The `cloudflare_dns_record.default` resource now includes:
  - `data = lookup(each.value, "data", null)`
  - `settings = lookup(each.value, "settings", null)`
- These fields are only applied when explicitly provided in the `records` input.